### PR TITLE
[#48] Ignore diacritics (ă,â,î,ș,ț,ş,ţ) when performing a search

### DIFF
--- a/static/js/search.js
+++ b/static/js/search.js
@@ -6,6 +6,21 @@ $(function () {
     var api = '/api/ngos';
     var searcEl = $("#search-bar");
     var ngos = [];
+    var latinCharMap = {
+      'ă': 'a',
+      'â': 'a',
+      'î': 'i',
+      'ș': 's', // comma
+      'ț': 't',
+      'ş': 's', // cedilla
+      'ţ': 't'
+    };
+
+    function latinise(str) {
+      return str.replace(/[^\u0000-\u007E]/g, function(c) {
+        return latinCharMap[c] || c;
+      });
+    }
 
     function setupEasyAutocomplete() {
         var options = {
@@ -27,7 +42,10 @@ $(function () {
                     window.location.href = selected.url;
                 },
                 match: {
-                    enabled: true
+                    enabled: true,
+                    method: function (element, phrase) {
+                      return latinise(element).search(latinise(phrase)) > -1;
+                    }
                 }
             }
         };


### PR DESCRIPTION
It will ignore just the diacritics used in the Romanian alphabet (including ş,ţ which are not correct, but are often used). And since the match is case insensitive, `latinCharMap` contains only lowercase characters.

As mentioned in #48, I think we shouldn't highlight the results since it's not a perfect match (i.e. `Dăruiește Viață` won't be highlighted if you search for `daruieste viata`). It's also not possible with this current version of `EasyAutocomplete` and contributing to that library might take a while.

[Click here](https://codepen.io/0merta/pen/XWJLNpx) for a live demo.