### PR TITLE
add responsive canvas signature

### DIFF
--- a/static/css/twopercent.less
+++ b/static/css/twopercent.less
@@ -148,6 +148,18 @@
     font-size: 0.8em;
 }
 
+// #signature {
+//     width: 500px;
+//     height: 150px;
+// }
+
+.signature-title-wrapper{
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    margin-bottom: 8px;
+}
+
 .instructions-row {
     margin-top: 50px;
     margin-bottom: 50px;

--- a/static/js/twopercent.js
+++ b/static/js/twopercent.js
@@ -158,6 +158,26 @@ $(function () {
         anchor.click();
     }
 
+    
+    // ######## signature ########
+
+    var canvas = document.getElementById("signature");
+    var twpPercWrapper = document.getElementById("twopercent-form-wrapper");
+    var signaturePad
+    window.addEventListener('resize', resizeCanvas, false);
+    function resizeCanvas() {
+        canvas.width = twpPercWrapper.clientWidth - 30;
+        canvas.height = 150;
+
+        signaturePad = new SignaturePad(canvas, { drawOnly:true, lineTop:200, penWidth: 1, lineWidth: 1 });
+    }
+    resizeCanvas();
+    $('#clear-signature').on('click', function(){
+        signaturePad.clear();
+    });
+
+    // ----- signature -------
+
     window.onSubmit = function(token) {
 
         submitFormButton.removeClass("btn-primary").addClass("btn-success").attr("disabled", true);
@@ -216,4 +236,5 @@ $(function () {
             }
         });
     };
+
 });

--- a/views/twopercent.html
+++ b/views/twopercent.html
@@ -12,6 +12,7 @@
 
     {# load the recaptcha api #}
     <script src='https://www.google.com/recaptcha/api.js?hl=ro' async defer></script>
+    <script src="https://cdn.jsdelivr.net/npm/signature_pad@3.0.0-beta.4/dist/signature_pad.umd.min.js" async defer></script>
 {% endblock %}
 
 {# error messages, also found in the js file twopercent.js #}
@@ -57,7 +58,7 @@
         </div> #}
 
         <div class="row">
-            <div class="col-xs-12 col-sm-10 col-sm-offset-1 col-md-8 col-md-offset-2 col-lg-8 col-lg-offset-2">
+            <div id="twopercent-form-wrapper" class="col-xs-12 col-sm-10 col-sm-offset-1 col-md-8 col-md-offset-2 col-lg-8 col-lg-offset-2">
                 <h2 id="donation-page-title">Redirecționează în 3 pași simpli</h2>
                 <h3 class="donation-page-subtitle">1. Completează și descarcă formularul</h3>
                 {% if ngo.account and ngo.cif %}
@@ -155,11 +156,32 @@
                             </div>
                         </fieldset> #}
                         <fieldset>
+                            <div class="signature-title-wrapper">
+                                <legend>Semnătura</legend>
+                                <button id="clear-signature" class="btn btn-primary" type="button">
+                                    Reseteaza
+                                </button>
+                            </div>
+                            <div class="form-group">
+                                <div class="col-xs-12">
+                                    <canvas id="signature" width="600" height="200" style="border: 1px solid #ddd;"></canvas>
+                                </div>
+                            </div>
+                        </fieldset>
+                        <fieldset>
                             <div class="form-group">
                                 <div class="col-xs-12 col-lg-10 checkbox">
                                     <label for="two-years">
                                         <input id="two-years" type="checkbox" name="two-years" />
                                         Vreau ca redirecționarea să se realizeze pe o perioadă de 2 ani
+                                    </label>
+                                </div>
+                            </div>
+                            <div class="form-group">
+                                <div class="col-xs-12 col-lg-10 checkbox">
+                                    <label for="two-years">
+                                        <input id="two-years" type="checkbox" name="two-years" />
+                                       Sunt de acord ca semnatura sa fie prelucrata.
                                     </label>
                                 </div>
                             </div>


### PR DESCRIPTION
### What does it fix?

- It adds a signature option when donating to NGO's.
- It integrates the `signaturePad 3.0.0-beta` plugin. [here](https://www.jsdelivr.com/package/npm/signature_pad)
- The canvas is responsive to the width of the wrapper.
- If the window is resized while a signature is present, the user will have to sign again.
- It has a reset button for resetting the signature
- It needs to be bonded with the backend.

### How has it been tested?

![bfeb7107a73f80e26ea06854d4720a20](https://user-images.githubusercontent.com/30385700/107847127-2aee4d00-6de9-11eb-85d6-98fb6219da2b.png)

