### PR TITLE
Log the exception types too

### DIFF
--- a/controllers/account_management.py
+++ b/controllers/account_management.py
@@ -135,8 +135,7 @@ class SignupHandler(AccountHandler):
             self.auth.set_session(self.auth.store.user_to_dict(user), remember=True)
             # redirect to my account
             self.redirect(self.uri_for('contul-meu'))
-        except Exception, e:
-            
+        except Exception as e:
             self.template_values["errors"] = u"Se pare că a aparut o problemă. Te rugăm să încerci din nou"
             self.render()
 

--- a/controllers/admin.py
+++ b/controllers/admin.py
@@ -49,7 +49,7 @@ class AdminHome(BaseHandler):
                 projection = [NgoEntity.county, NgoEntity.date_created]
                 # ngos = NgoEntity.query(NgoEntity.date_created < from_date).fetch(projection=projection)
                 ngos = []
-            except Exception, e:
+            except Exception as e:
                 error(e)
                 ngos = NgoEntity.query(NgoEntity.date_created < from_date).fetch()
 
@@ -122,7 +122,7 @@ class AdminNgosList(BaseHandler):
         try:
             projection = [NgoEntity.name, NgoEntity.county, NgoEntity.verified, NgoEntity.email]
             ngos = NgoEntity.query().fetch(projection=projection)
-        except Exception, e:
+        except Exception as e:
             ngos = NgoEntity.query().fetch()
 
         # for ngo in ngos:

--- a/controllers/api.py
+++ b/controllers/api.py
@@ -177,7 +177,7 @@ class GetNgoForms(AccountHandler):
 
             httpresp.close()
 
-        except Exception, e:
+        except Exception as e:
             exception(e)
 
             # if job failed to start remotely

--- a/controllers/captcha.py
+++ b/controllers/captcha.py
@@ -55,7 +55,7 @@ def submit(recaptcha_response_field, private_key, remoteip):
         response = json.decode( httpresp.read() )
         httpresp.close()
     
-    except Exception, e:
+    except Exception as e:
         return RecaptchaResponse(is_valid=False)
 
 

--- a/controllers/my_account.py
+++ b/controllers/my_account.py
@@ -401,7 +401,7 @@ class NgoDetailsHandler(AccountHandler):
             #     body = self.jinja_enviroment.get_template("email/admin/new-ngo.txt").render(values)
             #     # info(body)
             #     mail.send_mail(sender=CONTACT_EMAIL_ADDRESS, to="donezsieu@gmail.com", subject=subject, body=body)
-            # except Exception, e:
+            # except Exception as e:
             #     info(e)
 
             # do a refresh

--- a/controllers/ngo.py
+++ b/controllers/ngo.py
@@ -94,7 +94,7 @@ class TwoPercentHandler(BaseHandler):
                 else:
                     raise
 
-            except Exception, e:
+            except Exception as e:
 
                 self.template_values["ngo_website"] = None
         else:

--- a/controllers/site.py
+++ b/controllers/site.py
@@ -564,7 +564,7 @@ class HomePage(BaseHandler):
                 list_keys = sample(list_keys, 4)
 
                 ngos = get_multi(list_keys)
-            except Exception, e:
+            except Exception as e:
                 info(e)
                 ngos = NgoEntity.query(NgoEntity.active == True).fetch(4)
 

--- a/models/email.py
+++ b/models/email.py
@@ -84,21 +84,21 @@ class EmailManager(object):
             return True
 
         # if it failed through SMTP, try sendgrid as backup
-        warn(u"Failed to send SMTP email: {0}".format(kwargs.get("subject")))
+        warn(u"Failed to send SMTP email: {0} {1}".format(
+            kwargs.get("receiver", ""), kwargs.get("subject", "")))
 
         try:
             response = EmailManager.send_sendgrid_email(**kwargs)
-
-            # if False then the send failed
-            if response is False:
-                error_message = u"Failed to send email: {0}".format(kwargs.get("subject"))
-
-            return response
-
-        except Exception, e:
-            
+        except Exception as e:
+            warn(type(e).__name__)
             warn(e)
-            return False
+
+        # if the response is still False then the send failed
+        if response is False:
+            warn(u"Failed to send Sendgrid email: {0} {1}".format(
+                kwargs.get("receiver", ""), kwargs.get("subject", "")))
+
+        return response
 
 
     @staticmethod
@@ -142,10 +142,8 @@ class EmailManager(object):
         if response.status_code == 202:
             return True
         else:
-            
             warn(response.status_code)
             warn(response.body)
-
             return False
 
  
@@ -188,7 +186,8 @@ class EmailManager(object):
 
             return True
 
-        except Exception, e:
+        except Exception as e:
+            warn(type(e).__name__)
             warn(e)
 
             return False

--- a/models/handlers.py
+++ b/models/handlers.py
@@ -147,7 +147,7 @@ class BaseHandler(Handler):
                     raise TypeError("Type not serializable")
 
             self.response.write( json.encode(obj, default=json_serial) )
-        except Exception, e:
+        except Exception as e:
             exception(e)
 
             obj = {
@@ -252,7 +252,7 @@ class BaseHandler(Handler):
                 "name": u"{0} {1}".format(user.first_name, user.last_name),
                 "email": u"{0}".format(user.email)
             }
-        except Exception, e:
+        except Exception as e:
             warn(e)
             return
 
@@ -343,7 +343,7 @@ class BaseHandler(Handler):
 
             EmailManager.send_email(sender=sender, receiver=receiver, subject=subject, text_template=text_body, html_template=html_body)
 
-        except Exception, e:
+        except Exception as e:
             exception(e)
 
     def send_dynamic_email(self, template_id=None, email=None, data={}):


### PR DESCRIPTION
Use the recommended exception assignment `"except EXCEPTION as e"` (since Python 2.6) instead of the more ambiguous `"except EXCEPTION, e"`.

Log as warning the destination email address besides the email subject for failed deliveries.

Log as warning the types of the caught SMTP and Sendgrid exceptions.