### PR TITLE
Add unit tests for User model and configure dedicated test database

### DIFF
--- a/backend/redirectioneaza/settings/database.py
+++ b/backend/redirectioneaza/settings/database.py
@@ -1,4 +1,5 @@
 from .environment import env
+import sys
 
 # Database
 # https://docs.djangoproject.com/en/4.2/ref/settings/#databases
@@ -17,3 +18,12 @@ DATABASES = {
 # https://docs.djangoproject.com/en/4.2/ref/settings/#default-auto-field
 
 DEFAULT_AUTO_FIELD = "django.db.models.BigAutoField"
+
+# If we’re running tests, point at a dedicated test DB on localhost
+if "test" in sys.argv:
+    DATABASES["default"].update({
+        "NAME": env("TEST_DATABASE_NAME", default="redirectioneaza_test"),
+        "HOST": env("TEST_DATABASE_HOST", default="localhost"),
+        "USER": env("TEST_DATABASE_USER", default=env("DATABASE_USER")),
+        "PASSWORD": env("TEST_DATABASE_PASSWORD", default=env("DATABASE_PASSWORD")),
+    })

--- a/backend/redirectioneaza/settings/database.py
+++ b/backend/redirectioneaza/settings/database.py
@@ -21,9 +21,11 @@ DEFAULT_AUTO_FIELD = "django.db.models.BigAutoField"
 
 # If we’re running tests, point at a dedicated test DB on localhost
 if "test" in sys.argv:
-    DATABASES["default"].update({
-        "NAME": env("TEST_DATABASE_NAME", default="redirectioneaza_test"),
-        "HOST": env("TEST_DATABASE_HOST", default="localhost"),
-        "USER": env("TEST_DATABASE_USER", default=env("DATABASE_USER")),
-        "PASSWORD": env("TEST_DATABASE_PASSWORD", default=env("DATABASE_PASSWORD")),
-    })
+    DATABASES["default"].update(
+        {
+            "NAME": env("TEST_DATABASE_NAME", default="redirectioneaza_test"),
+            "HOST": env("TEST_DATABASE_HOST", default="localhost"),
+            "USER": env("TEST_DATABASE_USER", default=env("DATABASE_USER")),
+            "PASSWORD": env("TEST_DATABASE_PASSWORD", default=env("DATABASE_PASSWORD")),
+        }
+    )

--- a/backend/users/tests.py
+++ b/backend/users/tests.py
@@ -1,1 +1,120 @@
 # Create your tests here.
+import uuid
+from django.test import TestCase, override_settings
+from django.urls import reverse
+from django.utils import timezone
+from django.contrib.auth.models import Group
+
+from users.models import User, CustomUserManager
+from users.groups_management import MAIN_ADMIN, NGO_ADMIN, NGO_MEMBER, RESTRICTED_ADMIN
+
+
+class UserModelTests(TestCase):
+    def setUp(self):
+        # Create groups for role tests
+        self.main_admin_group = Group.objects.create(name=MAIN_ADMIN)
+        self.ngo_admin_group = Group.objects.create(name=NGO_ADMIN)
+        self.ngo_member_group = Group.objects.create(name=NGO_MEMBER)
+        self.restricted_admin_group = Group.objects.create(name=RESTRICTED_ADMIN)
+
+    def test_create_user_defaults(self):
+        user = User.objects.create_user(email="user@example.com", password="secret")
+        self.assertFalse(user.is_staff)
+        self.assertFalse(user.is_superuser)
+        self.assertTrue(user.check_password("secret"))
+        self.assertEqual(user.email, "user@example.com")
+
+    def test_create_superuser_success(self):
+        superuser = User.objects.create_superuser(email="admin@example.com", password="adminpass")
+        self.assertTrue(superuser.is_staff)
+        self.assertTrue(superuser.is_superuser)
+        self.assertTrue(superuser.check_password("adminpass"))
+
+    def test_create_superuser_invalid_flags(self):
+        # is_staff must be True
+        with self.assertRaisesMessage(ValueError, "Superuser must have is_staff=True."):
+            User.objects.create_superuser(email="x@example.com", password="pass", is_staff=False)
+        # is_superuser must be True
+        with self.assertRaisesMessage(ValueError, "Superuser must have is_superuser=True."):
+            User.objects.create_superuser(email="y@example.com", password="pass", is_superuser=False)
+
+    def test_refresh_and_verify_token(self):
+        user = User.objects.create_user(email="t@example.com", password="pw")
+        # Initially no token
+        self.assertIsNone(user.validation_token)
+        self.assertIsNone(user.token_timestamp)
+
+        token = user.refresh_token()
+        self.assertIsNotNone(user.validation_token)
+        self.assertIsNotNone(user.token_timestamp)
+        self.assertEqual(token, user.validation_token)
+
+        # verify matching token
+        self.assertTrue(user.verify_token(token))
+        # verify with wrong token
+        wrong = uuid.uuid4()
+        self.assertFalse(user.verify_token(wrong))
+        # verify when token cleared
+        user.clear_token()
+        self.assertFalse(user.verify_token(token))
+
+    def test_clear_token(self):
+        user = User.objects.create_user(email="clear@example.com", password="pw")
+        user.refresh_token()
+        user.clear_token()
+        self.assertIsNone(user.validation_token)
+        self.assertIsNone(user.token_timestamp)
+
+    def test_activate_deactivate(self):
+        user = User.objects.create_user(email="act@example.com", password="pw")
+        # default is_active=True from AbstractUser
+        user.deactivate()
+        self.assertFalse(user.is_active)
+        # calling again should not error
+        user.deactivate()
+        user.activate()
+        self.assertTrue(user.is_active)
+        # calling again should not error
+        user.activate()
+
+    def test_create_admin_login_url(self):
+        url_no_next = User.create_admin_login_url()
+        self.assertIn(reverse('admin:login'), url_no_next)
+        self.assertTrue(url_no_next.endswith('?next='))
+
+        next_path = '/dashboard/'
+        url_with_next = User.create_admin_login_url(next_url=next_path)
+        self.assertTrue(url_with_next.endswith(f'?next={next_path}'))
+
+    def test_group_properties(self):
+        user = User.objects.create_user(email="grp@example.com", password="pw")
+        # no groups
+        self.assertFalse(user.is_admin)
+        self.assertFalse(user.is_ngo_admin)
+        self.assertFalse(user.is_ngo_member)
+
+        # main admin
+        user.groups.add(self.main_admin_group)
+        self.assertTrue(user.is_admin)
+        self.assertFalse(user.is_ngo_admin)
+        self.assertFalse(user.is_ngo_member)
+        user.groups.clear()
+
+        # restricted admin
+        user.groups.add(self.restricted_admin_group)
+        self.assertTrue(user.is_admin)
+        user.groups.clear()
+
+        # ngo admin
+        user.groups.add(self.ngo_admin_group)
+        self.assertTrue(user.is_ngo_admin)
+        self.assertTrue(user.is_ngo_member)
+        self.assertFalse(user.is_admin)
+        user.groups.clear()
+
+        # ngo member
+        user.groups.add(self.ngo_member_group)
+        self.assertTrue(user.is_ngo_member)
+        self.assertFalse(user.is_ngo_admin)
+        self.assertFalse(user.is_admin)
+

--- a/backend/users/tests.py
+++ b/backend/users/tests.py
@@ -1,11 +1,11 @@
 # Create your tests here.
 import uuid
-from django.test import TestCase, override_settings
+from django.test import TestCase
 from django.urls import reverse
-from django.utils import timezone
 from django.contrib.auth.models import Group
+from django.utils.translation import gettext as _
 
-from users.models import User, CustomUserManager
+from users.models import User
 from users.groups_management import MAIN_ADMIN, NGO_ADMIN, NGO_MEMBER, RESTRICTED_ADMIN
 
 
@@ -32,7 +32,7 @@ class UserModelTests(TestCase):
 
     def test_create_superuser_invalid_flags(self):
         # is_staff must be True
-        with self.assertRaisesMessage(ValueError, "Superuser must have is_staff=True."):
+        with self.assertRaisesMessage(ValueError, _("Superuser must have is_staff=True.")):
             User.objects.create_superuser(email="x@example.com", password="pass", is_staff=False)
         # is_superuser must be True
         with self.assertRaisesMessage(ValueError, "Superuser must have is_superuser=True."):
@@ -79,12 +79,12 @@ class UserModelTests(TestCase):
 
     def test_create_admin_login_url(self):
         url_no_next = User.create_admin_login_url()
-        self.assertIn(reverse('admin:login'), url_no_next)
-        self.assertTrue(url_no_next.endswith('?next='))
+        self.assertIn(reverse("admin:login"), url_no_next)
+        self.assertTrue(url_no_next.endswith("?next="))
 
-        next_path = '/dashboard/'
+        next_path = "/dashboard/"
         url_with_next = User.create_admin_login_url(next_url=next_path)
-        self.assertTrue(url_with_next.endswith(f'?next={next_path}'))
+        self.assertTrue(url_with_next.endswith(f"?next={next_path}"))
 
     def test_group_properties(self):
         user = User.objects.create_user(email="grp@example.com", password="pw")
@@ -117,4 +117,3 @@ class UserModelTests(TestCase):
         self.assertTrue(user.is_ngo_member)
         self.assertFalse(user.is_ngo_admin)
         self.assertFalse(user.is_admin)
-

--- a/backend/users/tests.py
+++ b/backend/users/tests.py
@@ -35,7 +35,7 @@ class UserModelTests(TestCase):
         with self.assertRaisesMessage(ValueError, _("Superuser must have is_staff=True.")):
             User.objects.create_superuser(email="x@example.com", password="pass", is_staff=False)
         # is_superuser must be True
-        with self.assertRaisesMessage(ValueError, "Superuser must have is_superuser=True."):
+        with self.assertRaisesMessage(ValueError, _("Superuser must have is_superuser=True.")):
             User.objects.create_superuser(email="y@example.com", password="pass", is_superuser=False)
 
     def test_refresh_and_verify_token(self):


### PR DESCRIPTION
This PR introduces a suite of unit tests for the User model (and its custom manager) in the users app, and updates the database settings so that tests run against a dedicated test database instead of the production/Postgres host. These changes improve confidence in user‑related functionality and ensure an isolated environment for running tests.

**What’s been changed**

users/tests.py

Added tests for `CustomUserManager.create_use`r and `create_superuser`, including invalid‑flag error cases.
Covered token lifecycle methods (`refresh_token,` `verify_token`, `clear_token`).
Verified _activate/deactivate_ behavior.
Tested `create_admin_login_ur`l URL generation.
Exercised group‑based properties (`is_admin`, `is_ngo_admin`, `is_ngo_member`) against all relevant roles.


redirectioneaza/settings/database.py

Imported sys and detect "test" in sys.argv.
When running tests, override `DATABASES['default'] `to point at a local `redirectioneaza_test` database (hosted on localhost) to avoid conflicts with production data.

**How to verify**

1. Make sure the redirectioneaza_test database exists locally (e.g. via `createdb redirectioneaza_test`).
2. Run` python manage.py test users` and confirm all 8 tests pass.

This lays the groundwork for broader test coverage across the project and ensures our CI/test runs are safe and repeatable.